### PR TITLE
Include merlin-sdk not framework

### DIFF
--- a/scheduling/build.gradle
+++ b/scheduling/build.gradle
@@ -22,7 +22,7 @@ dependencies {
   implementation "gov.nasa.ammos.aerie.procedural:constraints:" + project.aerieVersion
 
   // standard aerie deps
-  implementation 'gov.nasa.jpl.aerie:merlin-framework:' + project.aerieVersion
+  implementation 'gov.nasa.jpl.aerie:merlin-sdk:' + project.aerieVersion
   implementation 'gov.nasa.jpl.aerie:contrib:' + project.aerieVersion
   implementation 'gov.nasa.jpl.aerie:type-utils:' + project.aerieVersion
 


### PR DESCRIPTION
The scheduling package doesn't need anything from merlin-framework that isn't included in merlin-sdk. It shaves ~0.5 MB off the jar size.