### PR TITLE
Update to 4.2.1, fix small issues

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,7 @@
 REPOSITORY_DOCKER_URL=ghcr.io/nasa-ammos
 
 # choose a specific PlanDev version
-DOCKER_TAG=v4.0.0
+DOCKER_TAG=v4.2.1
 
 GITHUB_USER=
 GITHUB_TOKEN=

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cp scheduling/examples/SampleProcedure.java scheduling/src/main/java/scheduling/
 ```
 or
 ```sh
-cp constraints/examples/SampleActivityConstraint.java scheduling/src/main/java/constraints/procedures
+cp constraints/examples/SampleActivityConstraint.java scheduling/src/main/java/scheduling/constraints
 ```
 
 (For more involved example procedures, take a look at some [scheduling procedures in the PlanDev repo](https://github.com/NASA-AMMOS/plandev/blob/develop/procedural/examples/foo-procedures/src/main/java/gov/nasa/ammos/plandev/procedural/examples/fooprocedures/procedures/StayWellFed.java) and [constraint procedures in the modeling tutorial]())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,16 @@
-version: "3.7"
 services:
   aerie_action:
     container_name: aerie_action
     depends_on: [ "postgres" ]
     environment:
-      HASURA_GRAPHQL_ADMIN_SECRET: "${HASURA_GRAPHQL_ADMIN_SECRET}"
+      HASURA_GRAPHQL_JWT_SECRET: "${HASURA_GRAPHQL_JWT_SECRET}"
       LOG_FILE: console
       LOG_LEVEL: info
       MERLIN_GRAPHQL_URL: http://hasura:8080/v1/graphql
       AERIE_DB_HOST: postgres
       AERIE_DB_PORT: 5432
+      ACTION_COOKIE_NAMES: "${ACTION_COOKIE_NAMES:-}"
+      ACTION_CORS_ALLOWED_ORIGIN: "${ACTION_CORS_ALLOWED_ORIGIN:-}"
       ACTION_DB_USER: "${SEQUENCING_USERNAME}"
       ACTION_DB_PASSWORD: "${SEQUENCING_PASSWORD}"
       ACTION_LOCAL_STORE: /usr/src/app/action_file_store
@@ -165,6 +166,7 @@ services:
     environment:
       ORIGIN: http://localhost
       PUBLIC_ACTION_CLIENT_URL: http://localhost:27186
+      PUBLIC_ACTION_INCLUDE_CREDENTIALS: "false"
       PUBLIC_AERIE_FILE_STORE_PREFIX: "/usr/src/app/merlin_file_store/"
       PUBLIC_GATEWAY_CLIENT_URL: http://localhost:9000
       PUBLIC_GATEWAY_SERVER_URL: http://aerie_gateway:9000


### PR DESCRIPTION
* Update to Plandev v4.2.1
* Fix incorrect token in action server docker compose, causing auth failures when running actions
* Fix command for copying example constraints to correct location
* add new (optional) action cookie vars to docker compose